### PR TITLE
Understand mobiledoc v0.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/jbarone/mobiledoc
 
+go 1.13
+
 require github.com/pkg/errors v0.8.0

--- a/mobiledoc.go
+++ b/mobiledoc.go
@@ -84,7 +84,7 @@ func (md *Mobiledoc) Render(w io.Writer) error {
 	}
 
 	switch version {
-	case "0.3.0", "0.3.1":
+	case "0.3.0", "0.3.1", "0.3.2":
 		n, err := md.parseV03(mdmap)
 		if err != nil {
 			return errors.Wrap(err, "unable to parse mobiledoc")

--- a/mobiledoc_test.go
+++ b/mobiledoc_test.go
@@ -61,6 +61,7 @@ func TestRender(t *testing.T) {
 	tests := []string{
 		"empty_0.3.0",
 		"empty_0.3.1",
+		"empty_0.3.2",
 		"image_section_0.3.0",
 		"image_section_0.3.1",
 		"without_markup_0.3.0",
@@ -72,6 +73,7 @@ func TestRender(t *testing.T) {
 		"multi_marker_section_0.3.1",
 		"list_section_0.3.1",
 		"image_card_0.3.1",
+		"section_attributes_0.3.2",
 	}
 	for _, tt := range tests {
 		t.Run(tt, func(t *testing.T) {

--- a/testdata/empty_0.3.2.json
+++ b/testdata/empty_0.3.2.json
@@ -1,0 +1,7 @@
+{
+	"version": "0.3.2",
+	"atoms": [],
+	"cards": [],
+	"markups": [],
+	"sections": []
+}

--- a/testdata/markdown/section_attributes_0.3.2.golden
+++ b/testdata/markdown/section_attributes_0.3.2.golden
@@ -1,0 +1,2 @@
+Simple aligned example
+

--- a/testdata/section_attributes_0.3.2.json
+++ b/testdata/section_attributes_0.3.2.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.3.2",
+	"atoms": [],
+	"cards": [],
+	"markups": [],
+        "sections": [
+                [1, "p", [
+                        [0, [], 0, "Simple aligned example"]
+                ], ["data-md-text-align", "center"]]
+	]
+}


### PR DESCRIPTION
This version of the spec adds key-value attributes to sections, just
only the key data-md-text-align defined at this time. Since we're
outputting markdown that doesn't really do text alignment, we simply
ignore this argument. Add test coverage anyway.

The only description of the spec change I can find is in the pull
request ifself, https://github.com/bustle/mobiledoc-kit/pull/681